### PR TITLE
Use Mokkari to talk to Metron

### DIFF
--- a/Organizer/metron_api.py
+++ b/Organizer/metron_api.py
@@ -1,11 +1,9 @@
 import logging
-import time
-from datetime import datetime
-from json import JSONDecodeError
-from typing import Dict, Any, List, Tuple, Optional
-
-from requests import get
-from requests.exceptions import HTTPError, ConnectionError
+from typing import Dict, Any, List, Optional
+from mokkari import api, sqlite_cache
+from mokkari.issue import Issue
+from mokkari.publisher import Publisher
+from mokkari.series import Series
 
 from .comic_info import ComicInfo, IdentifierInfo
 from .console import Console
@@ -13,164 +11,136 @@ from .utils import METRON_USERNAME, METRON_PASSWORD, remove_extra
 
 LOGGER = logging.getLogger(__name__)
 
+class Talker:
+    def __init__(self, username: str, password: str, cache=None) -> None:
+        if not cache:
+            cache = "mokkari.sqlite"
+        self.api = api(username, password, sqlite_cache.SqliteCache(cache))
+
+    def search_publishers(self, name: str) -> Optional[int]:
+        LOGGER.debug('Search Publishers')
+        results = self.api.publishers_list(params={"name": name,})
+        if results:
+            index = Console.display_menu(items=[f"{item.id} - {item.name}" for item in results], exit_text='None of the Above', prompt='Select Publisher')
+            if 1 <= index <= len(results):
+                return results[index - 1].id
+        return None
+
+    def get_publisher(self, publisher_id: int) -> Publisher:
+        LOGGER.debug('Getting Publisher')
+        return self.api.publisher(publisher_id)
+
+    def search_series(self, publisher_id: int, name: str, volume: Optional[int] = None) -> Optional[int]:
+        LOGGER.debug('Search Series')
+        params = {'publisher_id': publisher_id, 'name': name,}
+        if volume:
+            params['volume'] = volume
+        results = self.api.series_list(params=params)
+        if results:
+            index = Console.display_menu(items=[f"{item.id} - {item.display_name}" for item in results], exit_text='None of the Above', prompt='Select Series')
+            if 1 <= index <= len(results):
+                return results[index - 1].id
+        return None
+
+    def get_series(self, series_id: int) -> Series:
+        LOGGER.debug('Getting Series')
+        return self.api.series(series_id)
+
+    def search_issues(self, series_id: int, number: str) -> Optional[int]:
+        LOGGER.debug('Search Issues')
+        params = {'series_id': series_id, 'number': number}
+        results = self.api.issues_list(params=params)
+        if results:
+            index = Console.display_menu(items=[f"{item.id} - {item.issue_name} [{item.cover_date}]" for item in results], exit_text='None of the Above', prompt='Select Issue')
+            if 1 <= index <= len(results):
+                return results[index - 1].id
+        return None
+
+    def get_issue(self, issue_id: int) -> Issue:
+        LOGGER.debug('Getting Issue')
+        return self.api.issue(issue_id)
+
 
 def add_info(comic_info: ComicInfo, show_variants: bool = False) -> ComicInfo:
+    talker = Talker(METRON_USERNAME, METRON_PASSWORD)
+
     comic_info.series.publisher.identifiers = [x for x in comic_info.series.publisher.identifiers if x.website.lower() != 'metron']
     comic_info.series.identifiers = [x for x in comic_info.series.identifiers if x.website.lower() != 'metron']
     comic_info.identifiers = [x for x in comic_info.identifiers if x.website.lower() != 'metron']
+
     if 'metron' in [x.website.lower() for x in comic_info.series.publisher.identifiers]:
         publisher_id = [x.identifier for x in comic_info.series.publisher.identifiers if x.website.lower() == 'metron'][0]
     else:
-        publisher_id = search_publishers(name=comic_info.series.publisher.title)
+        publisher_id = talker.search_publishers(name=comic_info.series.publisher.title)
     if not publisher_id:
         return comic_info
-    comic_info = parse_publisher_result(result=select_publisher(publisher_id=publisher_id), comic_info=comic_info)
+
+    comic_info = parse_publisher_result(result=talker.get_publisher(publisher_id), comic_info=comic_info)
     if 'metron' in [x.website.lower() for x in comic_info.series.identifiers]:
         series_id = [x.identifier for x in comic_info.series.identifiers if x.website.lower() == 'metron'][0]
     else:
-        series_id = search_series(publisher_id=[x.identifier for x in comic_info.series.publisher.identifiers if x.website.lower() == 'metron'][0], name=comic_info.series.title,
+        series_id = talker.search_series(publisher_id=[x.identifier for x in comic_info.series.publisher.identifiers if x.website.lower() == 'metron'][0], name=comic_info.series.title,
                                   volume=comic_info.series.volume)
     if not series_id:
         return comic_info
-    comic_info = parse_series_result(result=select_series(series_id=series_id), comic_info=comic_info)
+
+    comic_info = parse_series_result(result=talker.get_series(series_id), comic_info=comic_info)
     if 'metron' in [x.website.lower() for x in comic_info.identifiers]:
         issue_id = [x.identifier for x in comic_info.identifiers if x.website.lower() == 'metron'][0]
     else:
-        issue_id = search_issues(series_id=[x.identifier for x in comic_info.series.identifiers if x.website.lower() == 'metron'][0], number=comic_info.number)
+        issue_id = talker.search_issues(series_id=[x.identifier for x in comic_info.series.identifiers if x.website.lower() == 'metron'][0], number=comic_info.number)
     if not issue_id:
         return comic_info
-    return parse_issue_result(result=select_issue(issue_id=issue_id), comic_info=comic_info)
+
+    return parse_issue_result(result=talker.get_issue(issue_id), comic_info=comic_info)
 
 
-def parse_publisher_result(result: Dict[str, Any], comic_info: ComicInfo) -> ComicInfo:
+def parse_publisher_result(result:Publisher, comic_info: ComicInfo) -> ComicInfo:
     LOGGER.debug('Parse Publisher Results')
     if 'metron' not in [x.website.lower() for x in comic_info.series.publisher.identifiers]:
-        comic_info.series.publisher.identifiers.append(IdentifierInfo(website='Metron', identifier=result['id']))
-    comic_info.series.publisher.title = comic_info.series.publisher.title if comic_info.series.publisher.title else result['name']
+        comic_info.series.publisher.identifiers.append(IdentifierInfo(website='Metron', identifier=result.id))
+    comic_info.series.publisher.title = (comic_info.series.publisher.title or result.name)
+
     return comic_info
 
 
-def parse_series_result(result: Dict[str, Any], comic_info: ComicInfo) -> ComicInfo:
+def parse_series_result(result: Series, comic_info: ComicInfo) -> ComicInfo:
     LOGGER.debug('Parse Series Results')
     if 'metron' not in [x.website.lower() for x in comic_info.series.identifiers]:
-        comic_info.series.identifiers.append(IdentifierInfo(website='Metron', identifier=result['id']))
-    comic_info.series.title = comic_info.series.title if comic_info.series.title else result['name']
-    comic_info.series.volume = comic_info.series.volume if comic_info.series.volume else result['volume']
-    comic_info.series.start_year = comic_info.series.start_year if comic_info.series.start_year else result['year_began']
+        comic_info.series.identifiers.append(IdentifierInfo(website='Metron', identifier=result.id))
+    comic_info.series.title = comic_info.series.title or result.name
+    comic_info.series.volume = comic_info.series.volume or result.volume
+    comic_info.series.start_year = comic_info.series.start_year or result.year_began
+
     return comic_info
 
+def titles_to_string(titles: List[str]) -> str:
+    return "; ".join(map(str, titles))
 
-def parse_issue_result(result: Dict[str, Any], comic_info: ComicInfo) -> ComicInfo:
+
+def parse_issue_result(result: Issue, comic_info: ComicInfo) -> ComicInfo:
     LOGGER.debug('Parse Comic Results')
     if 'metron' not in [x.website.lower() for x in comic_info.identifiers]:
-        comic_info.identifiers.append(IdentifierInfo(website='Metron', identifier=result['id']))
-    comic_info.number = comic_info.number if comic_info.number else result['number']
-    comic_info.title = comic_info.title if comic_info.title else result['name'][0] if result['name'] else None
-    comic_info.cover_date = comic_info.cover_date if comic_info.cover_date else datetime.strptime(result['cover_date'], '%Y-%m-%d').date()
-    for credit in result['credits']:
-        for role in credit['role']:
-            if role['name'] not in comic_info.creators:
-                comic_info.creators[role['name']] = []
-            comic_info.creators[role['name']].append(credit['creator'])
+        comic_info.identifiers.append(IdentifierInfo(website='Metron', identifier=result.id))
+    comic_info.number = comic_info.number or result.number
+    comic_info.title = comic_info.title or (
+        titles_to_string(result.story_titles) if result.story_titles else None
+    )
+
+    comic_info.cover_date = comic_info.cover_date or result.cover_date
+
+    for credit in result.credits:
+        for role in credit.role:
+            if role.name not in comic_info.creators:
+                comic_info.creators[role.name] = []
+            comic_info.creators[role.name].append(credit.creator)
     # TODO: Comic Format
     # TODO: Genres
     # TODO: Language ISO
     # TODO: Page Count
-    comic_info.summary = comic_info.summary if comic_info.summary else remove_extra(result['desc'])
+    comic_info.summary = comic_info.summary or remove_extra(result.desc)
     # TODO: Variant
     return comic_info
-
-
-def search_publishers(name: str) -> Optional[int]:
-    LOGGER.debug('Search Publishers')
-    results = []
-    page = 1
-    params = [('name', name)]
-    result = __request('/publisher', params=params)
-    if result:
-        results.extend(result['results'])
-    while result and result['next']:
-        page += 1
-        temp_params = [*params, ('page', page)]
-        result = __request('/publisher', params=temp_params)
-        if result:
-            results.extend(result['results'])
-    if len(results) >= 1:
-        index = Console.display_menu(items=[f"{item['id']} - {item['name']}" for item in results], exit_text='None of the Above', prompt='Select Publisher')
-        if 1 <= index <= len(results):
-            return results[index - 1]['id']
-    return None
-
-
-def select_publisher(publisher_id: int) -> Dict[str, Any]:
-    LOGGER.debug('Select Publisher')
-    result = __request(f"/publisher/{publisher_id}")
-    if result:
-        return result
-    return {}
-
-
-def search_series(publisher_id: int, name: str, volume: Optional[int] = None) -> Optional[int]:
-    LOGGER.debug('Search Series')
-    results = []
-    page = 1
-    params = [('publisher_id', publisher_id), ('name', name)]
-    if volume:
-        params.append(('volume', volume))
-    result = __request('/series', params=params)
-    if result:
-        results.extend(result['results'])
-    while result and result['next']:
-        page += 1
-        temp_params = [*params, ('page', page)]
-        result = __request('/series', params=temp_params)
-        if result:
-            results.extend(result['results'])
-    if len(results) >= 1:
-        index = Console.display_menu(items=[f"{item['id']} - {item['__str__']}" for item in results], exit_text='None of the Above', prompt='Select Series')
-        if 1 <= index <= len(results):
-            return results[index - 1]['id']
-    elif volume:
-        return search_series(publisher_id=publisher_id, name=name)
-    return None
-
-
-def select_series(series_id: int) -> Dict[str, Any]:
-    LOGGER.debug('Select Series')
-    result = __request(f"/series/{series_id}")
-    if result:
-        return result
-    return {}
-
-
-def search_issues(series_id: int, number: str) -> Optional[int]:
-    LOGGER.debug('Search Issues')
-    results = []
-    page = 1
-    params = [('series_id', series_id), ('number', number)]
-    result = __request('/issue', params=params)
-    if result:
-        results.extend(result['results'])
-    while result and result['next']:
-        page += 1
-        temp_params = [*params, ('page', page)]
-        result = __request('/issue', params=temp_params)
-        if result:
-            results.extend(result['results'])
-    if len(results) >= 1:
-        index = Console.display_menu(items=[f"{item['id']} - {item['__str__']} [{item['cover_date']}]" for item in results], exit_text='None of the Above', prompt='Select Issue')
-        if 1 <= index <= len(results):
-            return results[index - 1]['id']
-    return None
-
-
-def select_issue(issue_id: int) -> Dict[str, Any]:
-    LOGGER.debug('Select Issue')
-    result = __request(f"/issue/{issue_id}")
-    if result:
-        return result
-    return {}
-
 
 def search_arcs(name: str) -> List[int]:
     LOGGER.debug('Search Arcs')
@@ -180,22 +150,3 @@ def search_arcs(name: str) -> List[int]:
 def select_arc(arc_id: int) -> Dict[str, Any]:
     LOGGER.debug('Select Arc')
     pass
-
-
-def __request(endpoint: str, params: List[Tuple[str, str]] = None) -> Dict[str, Any]:
-    if not params:
-        params = []
-    try:
-        response = get(url=f"https://metron.cloud/api{endpoint}", auth=(METRON_USERNAME, METRON_PASSWORD), headers={}, params=params)
-        if response.status_code == 200:
-            try:
-                LOGGER.info(f"{response.status_code}: GET - {response.url}")
-                return response.json()
-            except (JSONDecodeError, KeyError):
-                LOGGER.error(f'Unable to parse the response message: {response.text}')
-        return {}
-    except (HTTPError, ConnectionError) as err:
-        LOGGER.error(err)
-        return {}
-    finally:
-        time.sleep(0.5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ idna==3.2
 iniconfig==1.1.1
 lxml==4.6.3
 marshmallow==3.13.0
-mokkari==0.1.8
+mokkari==0.1.10
 packaging==21.0
 patool==1.12
 pluggy==0.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,24 @@
-ruamel.yaml == 0.17.10
-titlecase == 2.3
-requests == 2.26.0
-beautifulsoup4 == 4.9.3
-lxml == 4.6.3
-patool == 1.12
-
-# PyLogger submodule
-colorama == 0.4.4
+attrs==21.2.0
+beautifulsoup4==4.9.3
+certifi==2021.5.30
+charset-normalizer==2.0.4
+colorama==0.4.4
+idna==3.2
+iniconfig==1.1.1
+lxml==4.6.3
+marshmallow==3.13.0
+mokkari==0.1.8
+packaging==21.0
+patool==1.12
+pluggy==0.13.1
+py==1.10.0
+pyparsing==2.4.7
+pytest==6.2.4
+ratelimit==2.2.1
+requests==2.26.0
+ruamel.yaml==0.17.10
+ruamel.yaml.clib==0.2.6
+soupsieve==2.2.1
+titlecase==2.3
+toml==0.10.2
+urllib3==1.26.6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import os
+
+import pytest
+from Organizer.metron_api import Talker
+from mokkari import api, sqlite_cache
+
+from Organizer.utils import METRON_PASSWORD, METRON_USERNAME
+
+
+@pytest.fixture(scope="session")
+def talker():
+    return Talker(
+        METRON_USERNAME,
+        METRON_PASSWORD,
+        cache="tests/testing_mock.sqlite",
+    )

--- a/tests/test_metron_api.py
+++ b/tests/test_metron_api.py
@@ -1,0 +1,37 @@
+import datetime
+
+from Organizer.comic_info import ComicInfo, PublisherInfo, SeriesInfo
+from Organizer.metron_api import parse_issue_result, parse_publisher_result, parse_series_result
+
+# TODO: Make some fixtures for the PublisherInfo, SeriesInfo, and ComicInfo
+
+def test_parse_publisher(talker):
+    marvel = talker.get_publisher(1)
+    pub_info = PublisherInfo("Marvel")
+    ser_info = SeriesInfo(pub_info, "Death of the Inhumans")
+    ci = ComicInfo(ser_info, "1")
+    results = parse_publisher_result(marvel, ci)
+    assert results.series.publisher.title == "Marvel"
+
+
+def test_parse_series(talker):
+    inhumans = talker.get_series(1)
+    pub_info = PublisherInfo("Marvel")
+    ser_info = SeriesInfo(pub_info, "Death of the Inhumans")
+    ci = ComicInfo(ser_info, "1")
+    results = parse_series_result(inhumans, ci)
+    assert results.series.volume == 1
+    assert results.series.start_year == 2018
+    assert results.series.title == "Death of the Inhumans"
+
+
+def test_parse_issue(talker):
+    test_issue = talker.get_issue(1)
+    pub_info = PublisherInfo("Marvel")
+    ser_info = SeriesInfo(pub_info, "Death of the Inhumans")
+    ci = ComicInfo(ser_info, "1")
+    result = parse_issue_result(test_issue, ci)
+    assert result.number == "1"
+    assert result.title == "Chapter One: Vox"
+    assert result.cover_date == datetime.date(2018, 9, 1)
+    assert len(result.creators) == 5


### PR DESCRIPTION
Was doing my weekly review of Metron's server logs, and notices that you were hitting Metron numerous time for the same data (primarily Publish & Series queries). I wrote a python wrapper to Metron Api, Mokkari, that has basic caching and as an added bonus should simplify you code a bit.

You may want modify the code to regenerate the cache db periodically, though really most of the data once it's added to Metron doesn't change often, so that might not be necessary depends on your user-case.

Also, added some initial tests to verify the handling of the parsing code hasn't change.

Any questions, don't hesitate to contact me.
